### PR TITLE
defer sqlite related imports

### DIFF
--- a/zipgun/zipgun.py
+++ b/zipgun/zipgun.py
@@ -4,9 +4,13 @@ from collections import defaultdict
 import csv
 import glob
 import os
-import sqlite3
 
-from sqlitedict import SqliteDict
+try:
+    import sqlite3
+    from sqlitedict import SqliteDict
+except ImportError:
+    pass
+
 
 DATA_FILE = 'zipgun.db'
 


### PR DESCRIPTION
This change makes it possible to use zipgun on Google App Engine. Without this change, I get an error importing zipgun:

```
> ERROR    2014-07-11 01:56:36,611 wsgi.py:262] 
>> Traceback (most recent call last):
>> File "/opt/google-appengine-python/google/appengine/runtime/wsgi.py", line 239, in Handle
>>     handler = config_handle.add_wsgi_middleware(self._LoadHandler())
>>   File "/opt/google-appengine-python/google/appengine/runtime/wsgi.py", line 298, in _LoadHandler
>>     handler, path, err = LoadObject(self._handler)
>>   File "/opt/google-appengine-python/google/appengine/runtime/wsgi.py", line 84, in LoadObject
>>     obj = __import__(path[0])
>>   ...
>>   File "/usr/lib/python2.7/sqlite3/__init__.py", line 24, in <module>
>>     from dbapi2 import *
>>   File "/usr/lib/python2.7/sqlite3/dbapi2.py", line 28, in <module>
>>     from _sqlite3 import *
>>   File "/opt/google-appengine-python/google/appengine/tools/devappserver2/python/sandbox.py", line 850, in load_module
>>     raise ImportError('No module named %s' % fullname)
>> ImportError: No module named _sqlite3
```
